### PR TITLE
VPNA new fixes

### DIFF
--- a/etc/sabai/accelerator/acc_install.sh
+++ b/etc/sabai/accelerator/acc_install.sh
@@ -5,6 +5,7 @@ TOPDIR="$1"
 # copy config files
 mv $TOPDIR/files/etc/sabai/accelerator/network $TOPDIR/files/etc/config/network
 mv $TOPDIR/files/etc/sabai/accelerator/firewall $TOPDIR/files/etc/config/firewall
+mv $TOPDIR/files/etc/sabai/accelerator/firewall.user $TOPDIR/files/etc/config/firewall.user
 mv $TOPDIR/files/etc/sabai/accelerator/uhttpd $TOPDIR/files/etc/config/uhttpd
 
 # changing config

--- a/etc/sabai/accelerator/firewall.user
+++ b/etc/sabai/accelerator/firewall.user
@@ -1,0 +1,14 @@
+# This file is interpreted as shell script.
+# Put your custom iptables rules here, they will
+# be executed with each firewall (re-)start.
+
+# Internal uci firewall chains are flushed and recreated on reload, so
+# put custom rules into the root chains e.g. INPUT or FORWARD or into the
+# special user chains, e.g. input_wan_rule or postrouting_lan_rule.
+
+# allow traffic forwarding to the tunnel
+route="$(ip route | grep eth0 | grep '.0/' | awk '{print $1}')"
+iptables -I FORWARD -s $route -o tun+ -j ACCEPT
+iptables -I FORWARD -s $route -o pptp-vpn -j ACCEPT
+iptables -t nat -I POSTROUTING -o pptp-vpn  -j MASQUERADE
+iptables -t nat -I POSTROUTING -o tun+  -j MASQUERADE


### PR DESCRIPTION
Fixes for vpn forwarding. Implemented with iptables. fw3 doesn't matches forwarding from /etc/config/firewall. Iptables were added to firewall.user and included in firewall config. Speed was tested with different US servers. Average speed 15 Mbs. 